### PR TITLE
Add --max parameter so that we can sync more than 100 pictures

### DIFF
--- a/cmd/picsync/sync.go
+++ b/cmd/picsync/sync.go
@@ -29,6 +29,7 @@ var (
 	}
 
 	syncEvery string
+	maxPics   int
 )
 
 func init() {
@@ -39,6 +40,14 @@ func init() {
 		"",
 		"Sync every interval (like \"30s\" or \"1h\")",
 	)
+	sync.PersistentFlags().IntVarP(
+		&maxPics,
+		"max",
+		"n",
+		100,
+		"Maximum pictures to sync",
+	)
+
 	rootCmd.AddCommand(sync)
 }
 
@@ -116,7 +125,7 @@ func doSync(smugmugAlbumName string, nixplayAlbumName string) error {
 		return fmt.Errorf("Could not find SmugMug album %s", smugmugAlbumName)
 	}
 
-	smImages, err := smugmug.GetAlbumImages(smClient, smAlbum.AlbumKey)
+	smImages, err := smugmug.GetAlbumImages(smClient, smAlbum.AlbumKey, maxPics)
 	if err != nil {
 		return err
 	}

--- a/pkg/smugmug/albumimage.go
+++ b/pkg/smugmug/albumimage.go
@@ -64,9 +64,9 @@ func (i AlbumImage) String() string {
 }
 
 // GetAlbumImages will get the metadata for all images in an album
-func GetAlbumImages(c *http.Client, albumKey string) ([]*AlbumImage, error) {
+func GetAlbumImages(c *http.Client, albumKey string, maxPics int) ([]*AlbumImage, error) {
 	resp := albumImagesResponse{}
-	url := fmt.Sprintf("https://api.smugmug.com/api/v2/album/%s!images", albumKey)
+	url := fmt.Sprintf("https://api.smugmug.com/api/v2/album/%s!images?count=%d", albumKey, maxPics)
 	err := GetUnmarshalJSON(c, url, &resp)
 	return resp.Response.AlbumImage, err
 }


### PR DESCRIPTION
Problem: The SmugMug API defaults to returning the first 100 pictures,
so after the album has more than 100 pictures in it, the syncing stops
adding new photos.  (And it would probably delete some already existing
photos if deleting was implemented)

Solution: SmugMug API supports larger return sets (?count=1000) and also
pagination (?start=1001).  This commit doesn't implement pagination
because it's not clear that's a big win (we'd still have to load the
entirety of the smugmug album and nixplay album into working set in
order to do the set difference anyway).  But, set the count to a
user-specificed "--max" parameter.