### PR TITLE
Fix #2: Memory leak when uploading to Nixplay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ picsync-*.yaml
 picsync-metadata-cache.db
 .envrc
 __debug_bin
-picsync
+./picsync

--- a/README.md
+++ b/README.md
@@ -73,10 +73,15 @@ albums:
 # every: 10m
 every: 1h
 
-# Serve prometheus-compatible metrics
+# If long-running, serve prometheus-compatible metrics
+# This port should not be exposed to the internet
 prometheus:
   # Listen on port 1971 on every interface
   listen: ":1971"
+# If long-running, serve pprof profiles via port 8080
+# This port should not be exposed to the internet
+pprof:
+  listen: ":8080"
 ```
 
 The easiest way to create the .picsync-credentials.yaml file is to run

--- a/cmd/picsync/pprof.go
+++ b/cmd/picsync/pprof.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	// pprof automatically adds itself to the default HTTP handlers as a
+	// side-effect of loading it.
+	_ "net/http/pprof"
+)
+
+func pprofInitOrDie(listenAddr string) {
+	if listenAddr != "" {
+		go func() {
+			fmt.Println(http.ListenAndServe(listenAddr, nil))
+		}()
+		fmt.Printf("Pprof server listening at %s\n", listenAddr)
+	}
+}

--- a/cmd/picsync/syncGoogle.go
+++ b/cmd/picsync/syncGoogle.go
@@ -49,6 +49,7 @@ func runSync(cmd *cobra.Command, args []string) {
 	// Start prometheus
 	if config.Every != "" {
 		promInitOrDie(config.Prometheus.Listen)
+		pprofInitOrDie(config.Pprof.Listen)
 	}
 
 	clients := syncClients{}

--- a/picsync.yaml
+++ b/picsync.yaml
@@ -28,5 +28,11 @@ albums:
 every: 1h
 
 # If long-running, serve metrics via prometheus on port 1971
+# This port should not be exposed to the internet
 prometheus:
   listen: ":1971"
+
+# If long-running, serve pprof profiles via port 8080
+# This port should not be exposed to the internet
+pprof:
+  listen: ":8080"

--- a/pkg/nixplay/client.go
+++ b/pkg/nixplay/client.go
@@ -12,7 +12,7 @@ type Client interface {
 	GetAlbums() ([]*Album, error)
 	GetAlbumByName(albumName string) (*Album, error)
 	GetPhotos(albumID int) ([]*Photo, error)
-	UploadPhoto(albumID int, filename string, filetype string, filesize uint64, body io.Reader) error
+	UploadPhoto(albumID int, filename string, filetype string, filesize uint64, body io.ReadCloser) error
 	DeletePhoto(id int) error
 	CreatePlaylist(name string) (int, error)
 	GetPlaylists() ([]*Playlist, error)

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Albums     []*ConfigAlbum   `yaml:"albums"`
 	Every      string           `yaml:"every,omitempty"`
 	Prometheus ConfigPrometheus `yaml:"prometheus,omitempty"`
+	Pprof      ConfigPprof      `yaml:"pprof,omitempty"`
 }
 
 type ConfigAlbum struct {
@@ -26,6 +27,10 @@ type ConfigAlbumSources struct {
 }
 
 type ConfigPrometheus struct {
+	Listen string `yaml:"listen"`
+}
+
+type ConfigPprof struct {
 	Listen string `yaml:"listen"`
 }
 


### PR DESCRIPTION
Problem: A memory leak occurs when uploading photos to Nixplay.  For
high-ish res photos (20Megapixel-ish), this is enough to grow past 512MB
for the entire program after a few hundred photos (causing a pod with
default parameters to be killed in GKE).

Solution: Pprof snapshots demonstrated the problem was in uploadS3 and
related to the multipart MIME encoder.

There are two problems, both are fixed.

- The input body is not closed (io.Copy doesn't close it).  This is the
  body of the response from Google Photos.  We don't ever save the image
  to a file, we pipe directly from the HTTP GET of the googlephoto
  image, to the MIME encoder to put it into the body of the POST we do
  to upload it to S3.
  Not closing the input body could cause us to retain the connection to
  googlephotos (and prevent its reuse) and retain the bytes of the body
  (maybe).

- The response body from nixplay/S3 is not closed.  This is the response
  for the request that was the POST containing the image.  If the
  response isn't closed, the request may be retained, including the
  request body, which is the entire contents of the image.  I think this
  is the one more clearly indicated as the culprit from the heap dump.

After this, the heap dump does not show growth without bound, even when
uploading 50 pictures.