### PR TITLE
Fix #5: Could not create playlist

### DIFF
--- a/cmd/picsync/syncGoogle.go
+++ b/cmd/picsync/syncGoogle.go
@@ -144,7 +144,11 @@ func doSyncGooglephotos(clients syncClients, album *util.ConfigAlbum) error {
 	// Get the nixplay image metadata for the requested album
 	npAlbum, err := clients.nixplay.GetAlbumByName(album.Name)
 	if err != nil {
-		return err
+		fmt.Printf("Could not get nixplay album %s, creating.\n", album.Name)
+		npAlbum, err = clients.nixplay.CreateAlbum(album.Name)
+		if err != nil {
+			return err
+		}
 	}
 	npPhotos, err := clients.nixplay.GetPhotos(npAlbum.ID)
 	if err != nil {

--- a/pkg/nixplay/client.go
+++ b/pkg/nixplay/client.go
@@ -11,6 +11,7 @@ import (
 type Client interface {
 	GetAlbums() ([]*Album, error)
 	GetAlbumByName(albumName string) (*Album, error)
+	CreateAlbum(albumName string) (*Album, error)
 	GetPhotos(albumID int) ([]*Photo, error)
 	UploadPhoto(albumID int, filename string, filetype string, filesize uint64, body io.ReadCloser) error
 	DeletePhoto(id int) error

--- a/pkg/nixplay/playlist.go
+++ b/pkg/nixplay/playlist.go
@@ -51,6 +51,8 @@ func (c *clientImpl) CreatePlaylist(name string) (int, error) {
 		c.prom.createPlaylistFailure.Inc()
 		return -1, err
 	}
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("content-type", "application/json")
 	res, err := doNixplayCsrf(c.httpClient, req)
 	if err != nil {
 		c.prom.createPlaylistFailure.Inc()
@@ -69,7 +71,7 @@ func (c *clientImpl) CreatePlaylist(name string) (int, error) {
 	}
 
 	var resData createPlaylistResponseData
-	err = json.NewDecoder(res.Body).Decode(&resData)
+	err = json.NewDecoder(bytes.NewBuffer(resBody)).Decode(&resData)
 	if err != nil {
 		c.prom.createPlaylistFailure.Inc()
 		return -1, err

--- a/pkg/nixplay/prom.go
+++ b/pkg/nixplay/prom.go
@@ -20,6 +20,8 @@ type promImpl struct {
 	uploadPhotoTotalBytes    prometheus.Counter
 	deletePhotoSuccess       prometheus.Counter
 	deletePhotoFailure       prometheus.Counter
+	createAlbumSuccess       prometheus.Counter
+	createAlbumFailure       prometheus.Counter
 	createPlaylistSuccess    prometheus.Counter
 	createPlaylistFailure    prometheus.Counter
 	getPlaylistsSuccess      prometheus.Counter
@@ -103,6 +105,18 @@ func (c *clientImpl) promRegister(reg prometheus.Registerer) error {
 		prometheus.CounterOpts{
 			Name: "nixplay_upload_photos_bytes",
 			Help: "Total count of bytes of photos successfully uploaded",
+		},
+	)
+	c.prom.createAlbumSuccess = c.prom.promFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nixplay_create_album_success",
+			Help: "Successful creation of album",
+		},
+	)
+	c.prom.createAlbumFailure = c.prom.promFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nixplay_create_album_failure",
+			Help: "Failed creation of album",
 		},
 	)
 	c.prom.createPlaylistSuccess = c.prom.promFactory.NewCounter(


### PR DESCRIPTION
Problem: When nixplay has to create a playlist, this error message is always returned:

    Error syncing album Alle: couldn't create playlist ss_Alle: http 400: {"code":400,"message":"name (string) is required","name":"AssertionError"}

Solution: This is because we are not setting "content-type: application/json" in the request, so the Nixplay API does not know which decoder to apply to parse the request body.  Set "content-type: application/json" and it works.

Meanwhile, also add code to create the album if needed because that's another unfriendly step we require of first-time users.

Add prometheus counters for album creation.